### PR TITLE
Use WebJars versioned URLs (#1099)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'javax.cache:cache-api'
   runtimeOnly 'org.springframework.boot:spring-boot-starter-actuator'
-  runtimeOnly 'org.webjars:webjars-locator-core'
   runtimeOnly "org.webjars.npm:bootstrap:${webjarsBootstrapVersion}"
   runtimeOnly "org.webjars.npm:font-awesome:${webjarsFontawesomeVersion}"
   runtimeOnly 'org.ehcache:ehcache'

--- a/pom.xml
+++ b/pom.xml
@@ -90,10 +90,6 @@
 
     <!-- webjars -->
     <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>webjars-locator-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.webjars.npm</groupId>
       <artifactId>bootstrap</artifactId>
       <version>${webjars-bootstrap.version}</version>

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -17,7 +17,7 @@
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-  <link th:href="@{/webjars/font-awesome/css/font-awesome.min.css}" rel="stylesheet">
+  <link th:href="@{/webjars/font-awesome/4.7.0/css/font-awesome.min.css}" rel="stylesheet">
   <link rel="stylesheet" th:href="@{/resources/css/petclinic.css}" />
 
 </head>
@@ -87,7 +87,7 @@
     </div>
   </div>
 
-  <script th:src="@{/webjars/bootstrap/dist/js/bootstrap.bundle.min.js}"></script>
+  <script th:src="@{/webjars/bootstrap/5.1.3/dist/js/bootstrap.bundle.min.js}"></script>
 
 </body>
 


### PR DESCRIPTION
In order to improve efficiency (see spring-projects/spring-framework#27619) and allow native image compatibility, this commit uses WebJars versioned URLs which are supported out of the box on Spring Boot via /META-INF/resources default resource location configuration, removing the need to use webjars-locator-core dependency and WebJarsResourceResolver.

I have been able to measure a consistent 5% startup time improvement on the JVM with that simple change on my local machine.